### PR TITLE
Test open api fix

### DIFF
--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -492,7 +492,7 @@ definitions:
     required: ['checksum', 'type']
     description: The checksum value and its type
     example: 
-      - checksum: '77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182' 
+      - checksum: 77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182 
         type: sha256
     properties:
       checksum:
@@ -715,7 +715,7 @@ definitions:
           A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. 
           This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
         example: 
-          - checksum: '77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182' 
+          - checksum: 77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182
             type: sha256
       image_type:
         $ref: '#/definitions/ImageType'

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -767,8 +767,8 @@ definitions:
         description: >- 
           A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. 
         example:
-          - checksum: ea2a5db69bd20a42976838790bc29294df3af02b
-            type: sha1
+          - checksum: 77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182
+            type: sha256
       url:
         type: string
         description: >-

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -490,6 +490,10 @@ definitions:
   Checksum:
     type: object
     required: ['checksum', 'type']
+    description: The checksum value and its type
+    example: 
+      - checksum: '77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182' 
+        type: sha256
     properties:
       checksum:
         type: string


### PR DESCRIPTION
For part 2 of 2 https://ucsc-cgl.atlassian.net/browse/SEAB-1831

Checksum model didn't have an example or description.  For some reason, swagger-openapi-maven-plugin decided to take it from other 2 models that have the Checksum model.

Checksum model now has an example/description, its new description appears to be respected. However, the example is not. Altered example from the two models so it won't conflict with each other.