### PR TITLE
Galaxy support (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Schemas for the GA4GH Tool Registry API
 =======================================
 
-This repository is the home for the schema for the GA4GH Tool Registry API.  The goal of the API is to provide a standardized way to describe the availability of tools and workflows.  In this way, we can have multiple repositories that share Docker-based tools and WDL/CWL/Nextflow-based workflows and have a consistent way to interact, search, and retrieve information from these various registries.  The end goal is to make it much easier to share scientific tools and workflows, enhancing our ability to make research reproducible, sharable, and transparent.
+This repository is the home for the schema for the GA4GH Tool Registry API.  The goal of the API is to provide a standardized way to describe the availability of tools and workflows.  In this way, we can have multiple repositories that share Docker-based tools and WDL/CWL/Nextflow/Galaxy-based workflows and have a consistent way to interact, search, and retrieve information from these various registries.  The end goal is to make it much easier to share scientific tools and workflows, enhancing our ability to make research reproducible, sharable, and transparent.
 
 **See the human-readable [Reference Documentation](https://ga4gh.github.io/tool-registry-service-schemas). You can also explore the specification in the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh/tool-registry-schemas/develop/openapi/ga4gh-tool-discovery.yaml).**  *Manually load the JSON if working from a non-develop branch version.*
 
@@ -26,7 +26,7 @@ The Containers & Workflows working group is an informal, multi-vendor working gr
 What is the Tool Registry API Schema?
 -------------------------------------
 
-This is the home of the schema for the GA4GH Tool Registry API. The GA4GH Tool Registry API is a standard for listing and describing available tools (both stand-alone, Docker-based tools as well as workflows in CWL, WDL or Nextflow) in a given registry. This defines a minimal, common API describing tools that we propose for support by multiple tool/workflow registries like [Dockstore](https://www.dockstore.org/), [BioContainers](https://biocontainers.pro), and [Agora](https://github.com/broadinstitute/agora) for the purposes of exchange, indexing, and searching.
+This is the home of the schema for the GA4GH Tool Registry API. The GA4GH Tool Registry API is a standard for listing and describing available tools (both stand-alone, Docker-based tools as well as workflows in CWL, WDL, Nextflow, or Galaxy) in a given registry. This defines a minimal, common API describing tools that we propose for support by multiple tool/workflow registries like [Dockstore](https://www.dockstore.org/), [BioContainers](https://biocontainers.pro), and [Agora](https://github.com/broadinstitute/agora) for the purposes of exchange, indexing, and searching.
 
 This repo uses the [HubFlow](https://datasift.github.io/gitflow/) scheme which is closely based on [GitFlow](https://nvie.com/posts/a-successful-git-branching-model/). In practice, this means that the master branch contains the last production release of the schema whereas the develop branch contains the latest development changes which will end up in the next production release. 
 As of July 2019, this means that the 1.0.0 version is described on master whereas the develop branch contains the 2.0.0-beta.3 version which will evolve into the 2.0.0 production release.

--- a/openapi/ga4gh-tool-discovery.yaml
+++ b/openapi/ga4gh-tool-discovery.yaml
@@ -5,7 +5,7 @@ info:
     Proposed API for GA4GH (Global Alliance for Genomics & Health) tool
     repositories. A tool consists of a set of container images that are paired
     with a set of documents. Examples of documents include CWL (Common Workflow
-    Language) or WDL (Workflow Description Language) or NFL (Nextflow) that
+    Language), WDL (Workflow Description Language), NFL (Nextflow), or GXFORMAT2 (Galaxy) that
     describe how to use those images and a set of specifications for those
     images (examples are Dockerfiles or Singularity recipes) that describe how
     to reproduce those images in the future. We use the following terminology, a
@@ -229,7 +229,7 @@ paths:
       operationId: toolsIdVersionsVersionIdTypeDescriptorGet
       description: >-
         Returns the descriptor for the specified tool (examples include CWL,
-        WDL, or Nextflow documents).
+        WDL, Nextflow, or Galaxy documents).
       tags:
         - GA4GH
       parameters:
@@ -239,8 +239,8 @@ paths:
           description: >-
             The output type of the descriptor. Plain types return the bare
             descriptor while the "non-plain" types return a descriptor wrapped
-            with metadata. Allowable values include "CWL", "WDL", "NFL",
-            "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
+            with metadata. Allowable values include "CWL", "WDL", "NFL", "GALAXY",
+            "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY".
           type: string
         - name: id
           in: path
@@ -290,7 +290,7 @@ paths:
             underlying implementation to determine which output type to return.
             Plain types return the bare descriptor while the "non-plain" types
             return a descriptor wrapped with metadata. Allowable values are
-            "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
+            "CWL", "WDL", "NFL", "GALAXY", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY".
           type: string
         - name: id
           in: path
@@ -343,7 +343,7 @@ paths:
           in: path
           description: >-
             The type of the underlying descriptor. Allowable values include
-            "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For
+            "CWL", "WDL", "NFL", "GALAXY", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY". For
             example, "CWL" would return an list of ToolTests objects while
             "PLAIN_CWL" would return a bare JSON list with the content of the
             tests.
@@ -392,7 +392,7 @@ paths:
           in: path
           description: >-
             The output type of the descriptor. Examples of allowable values are
-            "CWL", "WDL", and "NFL".
+            "CWL", "WDL", "NFL", "GALAXY".
           type: string
         - name: id
           in: path
@@ -717,7 +717,7 @@ definitions:
     type: string
     description: >-
       The type of descriptor that represents this version of the tool (e.g. CWL,
-      WDL, or NFL). Note that these files can also include associated
+      WDL, NFL, or GALAXY). Note that these files can also include associated
       Docker/container files  and test parameters that further describe a
       version of a tool.
     enum:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4,15 +4,15 @@ info:
   description: Proposed API for GA4GH (Global Alliance for Genomics & Health) tool
     repositories. A tool consists of a set of container images that are paired
     with a set of documents. Examples of documents include CWL (Common Workflow
-    Language) or WDL (Workflow Description Language) or NFL (Nextflow) that
-    describe how to use those images and a set of specifications for those
-    images (examples are Dockerfiles or Singularity recipes) that describe how
-    to reproduce those images in the future. We use the following terminology, a
-    "container image" describes a container as stored at rest on a filesystem, a
-    "tool" describes one of the triples as described above. In practice,
-    examples of "tools" include CWL CommandLineTools, CWL Workflows, WDL
-    workflows, and Nextflow workflows that reference containers in formats such
-    as Docker or Singularity.
+    Language), WDL (Workflow Description Language), NFL (Nextflow), or GXFORMAT2
+    (Galaxy) that describe how to use those images and a set of specifications
+    for those images (examples are Dockerfiles or Singularity recipes) that
+    describe how to reproduce those images in the future. We use the following
+    terminology, a "container image" describes a container as stored at rest on
+    a filesystem, a "tool" describes one of the triples as described above. In
+    practice, examples of "tools" include CWL CommandLineTools, CWL Workflows,
+    WDL workflows, and Nextflow workflows that reference containers in formats
+    such as Docker or Singularity.
   version: 2.0.0
 tags:
   - name: GA4GH
@@ -25,8 +25,8 @@ paths:
     get:
       summary: List one specific tool, acts as an anchor for self references
       operationId: toolsIdGet
-      description: This endpoint returns one specific tool (which has ToolVersions nested
-        inside it).
+      description: This endpoint returns one specific tool (which has ToolVersions
+        nested inside it).
       tags:
         - GA4GH
       parameters:
@@ -207,13 +207,13 @@ paths:
           description: An array of Tools that match the filter.
           headers:
             next_page:
-              description: A URL that can be used to reach the next page based on the
-                current offset and page record limit.
+              description: A URL that can be used to reach the next page based on the current
+                offset and page record limit.
               schema:
                 type: string
             last_page:
-              description: A URL that can be used to reach the last page based on the
-                current page record limit.
+              description: A URL that can be used to reach the last page based on the current
+                page record limit.
               schema:
                 type: string
             self_link:
@@ -245,8 +245,8 @@ paths:
     get:
       summary: Get the tool descriptor for the specified tool
       operationId: toolsIdVersionsVersionIdTypeDescriptorGet
-      description: Returns the descriptor for the specified tool (examples include CWL,
-        WDL, or Nextflow documents).
+      description: Returns the descriptor for the specified tool (examples include
+        CWL, WDL, Nextflow, or Galaxy documents).
       tags:
         - GA4GH
       parameters:
@@ -256,7 +256,7 @@ paths:
           description: The output type of the descriptor. Plain types return the bare
             descriptor while the "non-plain" types return a descriptor wrapped
             with metadata. Allowable values include "CWL", "WDL", "NFL",
-            "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
+            "GALAXY", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL", "PLAIN_GALAXY".
           schema:
             type: string
         - name: id
@@ -311,11 +311,12 @@ paths:
         - name: type
           in: path
           required: true
-          description: The output type of the descriptor. If not specified, it is up to the
-            underlying implementation to determine which output type to return.
-            Plain types return the bare descriptor while the "non-plain" types
-            return a descriptor wrapped with metadata. Allowable values are
-            "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
+          description: The output type of the descriptor. If not specified, it is up to
+            the underlying implementation to determine which output type to
+            return. Plain types return the bare descriptor while the "non-plain"
+            types return a descriptor wrapped with metadata. Allowable values
+            are "CWL", "WDL", "NFL", "GALAXY", "PLAIN_CWL", "PLAIN_WDL",
+            "PLAIN_NFL", "PLAIN_GALAXY".
           schema:
             type: string
         - name: id
@@ -328,8 +329,8 @@ paths:
         - name: version_id
           in: path
           required: true
-          description: An identifier of the tool version for this particular tool registry,
-            for example `v1`.
+          description: An identifier of the tool version for this particular tool
+            registry, for example `v1`.
           schema:
             type: string
         - name: relative_path
@@ -377,10 +378,10 @@ paths:
           required: true
           in: path
           description: The type of the underlying descriptor. Allowable values include
-            "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For
-            example, "CWL" would return an list of ToolTests objects while
-            "PLAIN_CWL" would return a bare JSON list with the content of the
-            tests.
+            "CWL", "WDL", "NFL", "GALAXY", "PLAIN_CWL", "PLAIN_WDL",
+            "PLAIN_NFL", "PLAIN_GALAXY". For example, "CWL" would return an list
+            of ToolTests objects while "PLAIN_CWL" would return a bare JSON list
+            with the content of the tests.
           schema:
             type: string
         - name: id
@@ -393,8 +394,8 @@ paths:
         - name: version_id
           in: path
           required: true
-          description: An identifier of the tool version for this particular tool registry,
-            for example `v1`.
+          description: An identifier of the tool version for this particular tool
+            registry, for example `v1`.
           schema:
             type: string
       responses:
@@ -425,8 +426,8 @@ paths:
   "/tools/{id}/versions/{version_id}/{type}/files":
     get:
       summary: Get a list of objects that contain the relative path and file type
-      description: Get a list of objects that contain the relative path and file type. The
-        descriptors are intended for use with the
+      description: Get a list of objects that contain the relative path and file type.
+        The descriptors are intended for use with the
         /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}
         endpoint.
       operationId: toolsIdVersionsVersionIdTypeFilesGet
@@ -437,7 +438,7 @@ paths:
           required: true
           in: path
           description: The output type of the descriptor. Examples of allowable values are
-            "CWL", "WDL", and "NFL".
+            "CWL", "WDL", "NFL", "GALAXY".
           schema:
             type: string
         - name: id
@@ -450,8 +451,8 @@ paths:
         - name: version_id
           in: path
           required: true
-          description: An identifier of the tool version for this particular tool registry,
-            for example `v1`.
+          description: An identifier of the tool version for this particular tool
+            registry, for example `v1`.
           schema:
             type: string
       responses:
@@ -483,10 +484,10 @@ paths:
     get:
       summary: Get the container specification(s) for the specified image.
       operationId: toolsIdVersionsVersionIdContainerfileGet
-      description: Returns the container specifications(s) for the specified image. For
-        example, a CWL CommandlineTool can be associated with one specification
-        for a container, a CWL Workflow can be associated with multiple
-        specifications for containers.
+      description: Returns the container specifications(s) for the specified image.
+        For example, a CWL CommandlineTool can be associated with one
+        specification for a container, a CWL Workflow can be associated with
+        multiple specifications for containers.
       tags:
         - GA4GH
       parameters:
@@ -500,8 +501,8 @@ paths:
         - name: version_id
           in: path
           required: true
-          description: An identifier of the tool version for this particular tool registry,
-            for example `v1`.
+          description: An identifier of the tool version for this particular tool
+            registry, for example `v1`.
           schema:
             type: string
       responses:
@@ -571,8 +572,8 @@ components:
     offset:
       name: offset
       in: query
-      description: Start index of paging. Pagination results can be based on numbers or
-        other values chosen by the registry implementor (for example, SHA
+      description: Start index of paging. Pagination results can be based on numbers
+        or other values chosen by the registry implementor (for example, SHA
         values). If this exceeds the current result set return an empty set.  If
         not specified in the request, this will start at the beginning of the
         results.
@@ -608,8 +609,8 @@ components:
       properties:
         path:
           type: string
-          description: Relative path of the file.  A descriptor's path can be used with the
-            GA4GH .../{type}/descriptor/{relative_path} endpoint.
+          description: Relative path of the file.  A descriptor's path can be used with
+            the GA4GH .../{type}/descriptor/{relative_path} endpoint.
         file_type:
           type: string
           enum:
@@ -620,8 +621,9 @@ components:
             - OTHER
     ToolClass:
       type: object
-      description: Describes a class (type) of tool allowing us to categorize workflows,
-        tasks, and maybe even other entities (such as services) separately.
+      description: Describes a class (type) of tool allowing us to categorize
+        workflows, tasks, and maybe even other entities (such as services)
+        separately.
       properties:
         id:
           type: string
@@ -635,8 +637,8 @@ components:
             accomplish.
     Tool:
       type: object
-      description: A tool (or described tool) is defined as a tuple of a descriptor file
-        (which potentially consists of multiple files), a set of container
+      description: A tool (or described tool) is defined as a tuple of a descriptor
+        file (which potentially consists of multiple files), a set of container
         images, and a set of instructions for creating those images.
       required:
         - url
@@ -690,8 +692,8 @@ components:
           description: Whether this tool has a checker tool associated with it.
         checker_url:
           type: string
-          description: Optional url to the checker tool that will exit successfully if this
-            tool produced the expected result given test data.
+          description: Optional url to the checker tool that will exit successfully if
+            this tool produced the expected result given test data.
         versions:
           description: A list of versions for this tool.
           type: array
@@ -699,8 +701,8 @@ components:
             $ref: "#/components/schemas/ToolVersion"
     ToolVersion:
       type: object
-      description: A tool version describes a particular iteration of a tool as described
-        by a reference to a specific image and/or documents.
+      description: A tool version describes a particular iteration of a tool as
+        described by a reference to a specific image and/or documents.
       required:
         - url
         - id
@@ -817,14 +819,15 @@ components:
         - Conda
     DescriptorType:
       type: string
-      description: The type of descriptor that represents this version of the tool (e.g.
-        CWL, WDL, or NFL). Note that these files can also include associated
-        Docker/container files  and test parameters that further describe a
-        version of a tool.
+      description: The type of descriptor that represents this version of the tool
+        (e.g. CWL, WDL, NFL, or GALAXY). Note that these files can also include
+        associated Docker/container files  and test parameters that further
+        describe a version of a tool.
       enum:
         - CWL
         - WDL
         - NFL
+        - GALAXY
     FileWrapper:
       type: object
       description: >


### PR DESCRIPTION
Issue is https://github.com/dockstore/dockstore/issues/3979

Looks like a bit of a mismatch, Dockstore advertises implementing TRS 2.0.0, but Galaxy post-dates the release of 2.0.0. 
We probably don’t want to tackle some other post-2.0.0 stuff like service info at this time so will do a targeted cherry-pick 

Original description below

----------------------
* Proposing new language for Galaxy-based workflows
* OpenAPI changed
* PR feedback

Co-authored-by: Travis CI User <travis@example.org>