### PR TITLE
add Snakemake support to v2 beta trs

### DIFF
--- a/src/main/resources/swagger/ga4gh-tool-discovery.yaml
+++ b/src/main/resources/swagger/ga4gh-tool-discovery.yaml
@@ -617,10 +617,11 @@ definitions:
   DescriptorType:
     type: string
     description: >-
-      The type of descriptor that represents this version of the tool (e.g. CWL,
+      The type of descriptor that represents this version of the tool (e.g. SMK, CWL,
       WDL, or NFL). Note that these files can also include associated Docker/container files 
       and test parameters that further describe a version of a tool
     enum:
+      - SMK
       - CWL
       - WDL
       - NFL


### PR DESCRIPTION
This adds support for the Snakemake workflow language in ga4gh trs v2-beta. The branch was derived from tag 2.0.0-beta.5_gxformat2, which is[ pointed to by the Dockstore webservice](https://github.com/dockstore/dockstore/blob/180b96e88c485764991f4b147df0f2a8244ea74e/dockstore-webservice/pom.xml#L1296). Its unclear if we really want make this change to this branch.

So what to do?