### PR TITLE
SEAB-5108: Add notebooks support

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -746,6 +746,7 @@ components:
         - GALAXY
         - SMK        
         - SERVICE
+        - IPYNB
     DescriptorTypeVersion:
       type: string
       description: The language version for a given descriptor type. The version should correspond
@@ -760,11 +761,13 @@ components:
         - NFL
         - GALAXY
         - SMK
+        - IPYNB
         - PLAIN_CWL
         - PLAIN_WDL
         - PLAIN_NFL
         - PLAIN_GALAXY
         - PLAIN_SMK
+        - PLAIN_IPYNB
     FileWrapper:
       type: object
       description: >

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -746,7 +746,7 @@ components:
         - GALAXY
         - SMK        
         - SERVICE
-        - IPYNB
+        - JUPYTER
     DescriptorTypeVersion:
       type: string
       description: The language version for a given descriptor type. The version should correspond
@@ -761,13 +761,13 @@ components:
         - NFL
         - GALAXY
         - SMK
-        - IPYNB
+        - JUPYTER
         - PLAIN_CWL
         - PLAIN_WDL
         - PLAIN_NFL
         - PLAIN_GALAXY
         - PLAIN_SMK
-        - PLAIN_IPYNB
+        - PLAIN_JUPYTER
     FileWrapper:
       type: object
       description: >


### PR DESCRIPTION
In order for the TRS `/files` endpoint (which is used by the Dockstore UI) to function properly for notebooks, the value `JUPYTER` needs to appear in the `DescriptorType` enums.  This PR makes the necessary adjustments to the schema.

https://ucsc-cgl.atlassian.net/browse/SEAB-5108